### PR TITLE
Use current vue-styleguidist version

### DIFF
--- a/generator/index.js
+++ b/generator/index.js
@@ -62,7 +62,7 @@ module.exports = (api, context) => {
         'styleguide:build': "vue-styleguidist build"
       },
       devDependencies: {
-        'vue-styleguidist': "^1.7.13",
+        'vue-styleguidist': "^3.14.3",
       }
     })
   }


### PR DESCRIPTION
The old version has dependency conflicts with the current vue-cli default versions.